### PR TITLE
Added revert functionality to onDrop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Then activate with jQuery like so:
 
 The `onDrop` callback function is called when the dragged element is dropped.
 The dropped element is passed in parameter in his current state.
+When true is returned in the callback, the dropped item will be restored to it's original position.
+Defaults to false, resulting in default drag-drop behavior.
 
 ### Events
 
@@ -85,13 +87,22 @@ These advanced config options are also available:
 * `collapsedClass` The class applied to lists that have been collapsed (default `'dd-collapsed'`)
 * `placeClass` The class of the placeholder element (default `'dd-placeholder'`)
 * `emptyClass` The class used for empty list placeholder elements (default `'dd-empty'`)
+* `origPosClass` The class applied to the list the currently dragging list element was dragged from. (default `dd-origpos`)
 * `expandBtnHTML` The HTML text used to generate a list item expand button (default `'<button data-action="expand">Expand></button>'`)
 * `collapseBtnHTML` The HTML text used to generate a list item collapse button (default `'<button data-action="collapse">Collapse</button>'`)
-* `onDrop` callback function used when the dragged element is dropped (default `function (item) {}`)
+* `onDrop` callback function used when the dragged element is dropped (default `function (item) { return false; }`)
 
 **Inspect the [Nestable Demo](http://dbushell.github.com/Nestable/) for guidance.**
 
 ## Change Log
+
+### 2nd February 2015
+
+* Added functionality for returning the dropped list element to it's original position when returning true in the `onDrop` callback. 
+
+### 3rd December 2014
+
+* Added `onDrop` callback
 
 ### 15th October 2012
 

--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -1,6 +1,8 @@
 /*!
  * Nestable jQuery Plugin - Copyright (c) 2012 David Bushell - http://dbushell.com/
  * Dual-licensed under the BSD or MIT licenses
+ *
+ * GIT-Version 151012. Modified by MiraiTech.nl
  */
 ;(function($, window, document, undefined)
 {
@@ -246,20 +248,15 @@
         {
             li.removeClass(this.options.collapsedClass);
             li.children('[data-action]').remove();
-
-            // Only allow removal of this (empty list) when the origPosClass wasn't applied.
-            // If we don't do this (keep the empty list), reverting will fail.
-            // We'll be giving another removal chance after actually dropping.
-            if (!li.children(this.options.listNodeName).hasClass(this.options.origPosClass)) {
-                li.children(this.options.listNodeName).remove();
-            }
+            li.children(this.options.listNodeName).remove();
         },
 
         dragStart: function(e)
         {
-            var mouse    = this.mouse,
-                target   = $(e.target),
-                dragItem = target.closest(this.options.itemNodeName);
+            var mouse       = this.mouse,
+                target      = $(e.target),
+                dragItemPos = target.closest(this.options.itemNodeName),
+                dragItem    = dragItemPos.clone();
 
             this.placeEl.css('height', dragItem.height());
 
@@ -273,11 +270,11 @@
             this.dragEl = $(document.createElement(this.options.listNodeName)).addClass(this.options.listClass + ' ' + this.options.dragClass);
             this.dragEl.css('width', dragItem.width());
 
-            // Add an original position class (origPosClass) to the current list. This way, we'll know where the item was (after dropping).
-            dragItem.parent(this.options.listNodeName).addClass(this.options.origPosClass);
+            // Replace the (actual) original item with a placeholder item (locateable by our origPosClass).
+            // This way, we'll know where the item was (after dropping).
+            dragItemPos.replaceWith("<li class='" + this.options.origPosClass + "'></li>");
+            dragItemPos.after(this.placeEl);
 
-            dragItem.after(this.placeEl);
-            dragItem[0].parentNode.removeChild(dragItem[0]);
             dragItem.appendTo(this.dragEl);
 
             $(document.body).append(this.dragEl);
@@ -303,16 +300,21 @@
             this.placeEl.replaceWith(el);
 
             this.dragEl.remove();
-            
-            // Did we revert? (Callback function, return true = revert) If so, find the origPosClass (attached to a list), remove the class, re-append the item.
+
+            // Did we revert? (Callback function, return true = revert)
+            // If so, find the origPosClass (attached to our placeholder) and replace it with out original item.
             if (this.options.onDrop(el)) {
-                this.dragRootEl.find("." + this.options.origPosClass).removeClass(this.options.origPosClass).append(el);
+                this.dragRootEl.find("." + this.options.origPosClass).replaceWith(el);
             } else {
-                // Looks like we're not reverting.. Let's remove the class from the list
-                parent = this.dragRootEl.find("." + this.options.origPosClass).removeClass(this.options.origPosClass);
-                // Hm, no children? Let's give the unset function another chance (see unsetParent for more info)
-                if (!parent.children().length) {
-                    this.unsetParent(parent.parent());
+                // Looks like we're not reverting.. Let's remove the placeholder (and if neccessary, it's parent)
+                placeholder = this.dragRootEl.find("." + this.options.origPosClass);
+                parentList = placeholder.parent();
+                placeholder.remove();
+
+                // Hm, no children? Let's give the unset function another chance.
+                // This will not remove the 'parent of our parent' as the name suggests, but it will remove our (now) empty list ('the' parent)
+                if (!parentList.children().length) {
+                    this.unsetParent(parentList.parent());
                 }
                 this.el.trigger('change');
                 if (this.hasNewRoot) {
@@ -383,7 +385,7 @@
                 mouse.distAxX = 0;
                 prev = this.placeEl.prev(opt.itemNodeName);
                 // increase horizontal level if previous sibling exists and is not collapsed
-                if (mouse.distX > 0 && prev.length && !prev.hasClass(opt.collapsedClass)) {
+                if (mouse.distX > 0 && prev.length && !prev.hasClass(opt.collapsedClass) && !prev.hasClass(opt.origPosClass)) {
                     // cannot increase level when item above is collapsed
                     list = prev.find(opt.listNodeName).last();
                     // check if depth limit has reached
@@ -409,6 +411,7 @@
                     if (!next.length) {
                         parent = this.placeEl.parent();
                         this.placeEl.closest(opt.itemNodeName).after(this.placeEl);
+                        console.log(parent.children().length);
                         if (!parent.children().length) {
                             this.unsetParent(parent.parent());
                         }


### PR DESCRIPTION
By returning true in the onDrop-callback, one can revert the nestable
item to it's original position.
This can be used for example to check for wether your nestable item is
a duplicate on/for the same nesting level.
